### PR TITLE
build: fix OpenBSD compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,7 +39,7 @@ fn main() {
     let (link_kind, lib_name) = match target_os.as_str() {
         "macos" | "ios" => ("dylib", "c++"), // Apple targets reject static linking
         "windows" => ("dylib", "msvcrt"),    // Use MSVC runtime on Windows
-        "freebsd" => (crt_kind, "c++"),      // FreeBSD uses "c++"
+        "freebsd" | "openbsd" => (crt_kind, "c++"),      // FreeBSD and OpenBSD use "c++"
         _ => (crt_kind, "stdc++"),           // Default for other systems (Linux, etc.)
     };
 


### PR DESCRIPTION
Enable compiling on OpenBSD

Fixes Cuprate/cuprate#465. Should be noted that due to `sysinfo` not supporting OpenBSD yet (GuillaumeGomez/sysinfo#1318), the total max memory will need to be configured manually in Cuprated.toml.